### PR TITLE
Docs: Update `uses` SHA to 1.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ action "Slack notification" {
 
 **NOTICE :** for stability purposes, it is recommended to use the action with an explicit commit SHA-1 :
 
-`uses = "Ilshidur/action-slack@2b45998"` (=> link to the commits list : https://github.com/Ilshidur/action-slack/commits/master)
+`uses = "Ilshidur/action-slack@e820f54"` (=> link to the commits list : https://github.com/Ilshidur/action-slack/commits/master)
 
 ### Arguments
 


### PR DESCRIPTION
👋 Thanks for an easy-to-use action. I was trying to use `EVENT_PAYLOAD` in my args earlier this morning and noticed it wasn't working because the docs recommend an old SHA at this point in the `uses` directive. I've updated that to the 1.4.0 release SHA.