### PR TITLE
Fix `syntax` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This GitHub action is part of a list of Actions that are located in an other rep
 
 ## Usage
 
-### New YML synthax
+### New YML syntax
 
 ```yaml
 - name: Slack notification
@@ -30,7 +30,7 @@ This GitHub action is part of a list of Actions that are located in an other rep
     args: 'A new commit has been pushed.'
 ```
 
-### (legacy) HCL synthax
+### (legacy) HCL syntax
 
 ```hcl
 action "Slack notification" {


### PR DESCRIPTION
I noticed you spell `syntax` as `synthax` in this repo and several other of your repos. I tried to see if this is a valid spelling in another locale, but I believe it's just a typo/misspelling. I can create PRs for your other repos too if you'd like